### PR TITLE
fix: World exclusion

### DIFF
--- a/src/main/java/team/devblook/akropolis/module/Module.java
+++ b/src/main/java/team/devblook/akropolis/module/Module.java
@@ -19,6 +19,7 @@
 
 package team.devblook.akropolis.module;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -38,6 +39,7 @@ public abstract class Module implements Listener {
     private final ModuleType moduleType;
     private List<String> disabledWorlds;
     private final CooldownManager cooldownManager;
+    private boolean disabledWorldsInvert = false; // valor por defecto
 
     protected Module(AkropolisPlugin plugin, ModuleType type) {
         this.plugin = plugin;
@@ -46,8 +48,22 @@ public abstract class Module implements Listener {
         this.disabledWorlds = new ArrayList<>();
     }
 
-    public void setDisabledWorlds(List<String> disabledWorlds) {
-        this.disabledWorlds = disabledWorlds;
+    public void setDisabledWorlds(List<String> disabledWorlds, boolean invert) {
+        this.disabledWorldsInvert = invert;
+
+        if (!invert) {
+            this.disabledWorlds = disabledWorlds;
+            return;
+        }
+
+        List<String> inverted = new ArrayList<>();
+        for (World world : Bukkit.getWorlds()) {
+            if (!disabledWorlds.contains(world.getName())) {
+                inverted.add(world.getName());
+            }
+        }
+
+        this.disabledWorlds = inverted;
     }
 
     public AkropolisPlugin getPlugin() {
@@ -56,14 +72,15 @@ public abstract class Module implements Listener {
 
     public boolean inDisabledWorld(Location location) {
         World world = location.getWorld();
-
         if (world == null) return false;
-
-        return disabledWorlds.contains(world.getName());
+        return inDisabledWorld(world);
     }
 
     public boolean inDisabledWorld(World world) {
-        return disabledWorlds.contains(world.getName());
+        String worldName = world.getName();
+        return disabledWorldsInvert
+                ? !disabledWorlds.contains(worldName)
+                : disabledWorlds.contains(worldName);
     }
 
     public boolean tryCooldown(UUID uuid, CooldownType type, long delay) {

--- a/src/main/java/team/devblook/akropolis/module/ModuleManager.java
+++ b/src/main/java/team/devblook/akropolis/module/ModuleManager.java
@@ -63,6 +63,7 @@ public class ModuleManager {
 
         FileConfiguration config = plugin.getConfigManager().getFile(ConfigType.SETTINGS).get();
         disabledWorlds = config.getStringList("disabled-worlds.worlds");
+        boolean invert = config.getBoolean("disabled-worlds.invert", false);
 
         if (config.getBoolean("disabled-worlds.invert")) {
             List<String> newDisabledWorlds = new ArrayList<>();
@@ -99,7 +100,7 @@ public class ModuleManager {
 
         for (Module module : modules.values()) {
             try {
-                module.setDisabledWorlds(disabledWorlds);
+                module.setDisabledWorlds(disabledWorlds, invert);
                 module.onEnable();
             } catch (Exception e) {
                 e.printStackTrace();

--- a/src/main/java/team/devblook/akropolis/module/modules/visual/scoreboard/ScoreboardManager.java
+++ b/src/main/java/team/devblook/akropolis/module/modules/visual/scoreboard/ScoreboardManager.java
@@ -75,7 +75,12 @@ public class ScoreboardManager extends Module {
     }
 
     public void createScoreboard(Player player) {
-        players.put(player.getUniqueId(), updateScoreboard(player.getUniqueId()));
+        if (inDisabledWorld(player.getLocation())) return; // ✅ Evita scoreboard en mundos deshabilitados
+
+        UUID uuid = player.getUniqueId();
+        if (!players.containsKey(uuid)) {
+            players.put(uuid, updateScoreboard(uuid));
+        }
     }
 
     public ScoreboardHelper updateScoreboard(UUID uuid) {
@@ -140,8 +145,16 @@ public class ScoreboardManager extends Module {
 
         if (inDisabledWorld(toWorld) && players.containsKey(player.getUniqueId())) {
             removeScoreboard(player);
-        } else if (!players.containsKey(player.getUniqueId())) {
+        } else if (!players.containsKey(player.getUniqueId()) && !inDisabledWorld(toWorld)) {
             Bukkit.getScheduler().runTaskLaterAsynchronously(getPlugin(), () -> createScoreboard(player), worldDelay);
         }
+    }
+
+    public boolean inDisabledWorld(World world) {
+        return super.inDisabledWorld(world);
+    }
+
+    public boolean inDisabledWorld(org.bukkit.Location location) {
+        return super.inDisabledWorld(location);
     }
 }

--- a/src/main/java/team/devblook/akropolis/module/modules/visual/tablist/TablistManager.java
+++ b/src/main/java/team/devblook/akropolis/module/modules/visual/tablist/TablistManager.java
@@ -52,6 +52,9 @@ public class TablistManager extends Module {
         players = new ArrayList<>();
 
         FileConfiguration config = getConfig(ConfigType.SETTINGS);
+        List<String> disabled = config.getStringList("disabled-worlds.worlds");
+        boolean invert = config.getBoolean("disabled-worlds.invert", false);
+        setDisabledWorlds(disabled, invert);
 
         header = String.join("\n", config.getStringList("tablist.header"));
         footer = String.join("\n", config.getStringList("tablist.footer"));
@@ -75,8 +78,12 @@ public class TablistManager extends Module {
     }
 
     public void createTablist(Player player) {
+        if (inDisabledWorld(player.getLocation())) return; // ✅ nuevo check de seguridad
+
         UUID uuid = player.getUniqueId();
-        players.add(uuid);
+        if (!players.contains(uuid)) {
+            players.add(uuid);
+        }
         updateTablist(uuid);
     }
 
@@ -133,6 +140,17 @@ public class TablistManager extends Module {
             return;
         }
 
+        if (!players.contains(player.getUniqueId()) && !inDisabledWorld(toWorld)) {
+            Bukkit.getScheduler().runTaskLaterAsynchronously(getPlugin(), () -> createTablist(player), 20L);
+        }
         createTablist(player);
+    }
+
+    public boolean inDisabledWorld(World world) {
+        return super.inDisabledWorld(world);
+    }
+
+    public boolean inDisabledWorld(org.bukkit.Location location) {
+        return super.inDisabledWorld(location);
     }
 }


### PR DESCRIPTION
Fixes have been made to the TAB. When you go to a barred world, it disappears.
Fixes have been made to the SCOREBOARD. When you go to a barred world, it disappears.
Fixed when the exclusion is reverted and becomes whitelisted.