### PR TITLE
fix: MiniPlaceholders v3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
     compileOnly("me.clip:placeholderapi:2.11.6")
     compileOnly("com.arcaniax:HeadDatabase-API:1.3.2")
     compileOnly("com.github.cryptomorin:XSeries:13.3.3")
-    compileOnly("io.github.miniplaceholders:miniplaceholders-api:2.3.0")
+    compileOnly("io.github.miniplaceholders:miniplaceholders-api:3.1.0")
     compileOnly("com.github.koca2000:NoteBlockAPI:1.6.2")
 }
 

--- a/src/main/java/me/zetastormy/akropolis/util/text/PlaceholderUtil.java
+++ b/src/main/java/me/zetastormy/akropolis/util/text/PlaceholderUtil.java
@@ -54,8 +54,12 @@ public class PlaceholderUtil {
                      .replace("<world>", player.getWorld().getName())
                      .replace("<location>", formatLocation(player.getLocation()));
 
-            if (papi) return TextUtil.parse(text, papiTag(player));
-            if (miniplaceholders) return TextUtil.parse(text, MiniPlaceholders.getAudienceGlobalPlaceholders(player));
+            return TextUtil.parse(
+                text,
+                player,
+                (papi) ? papiTag(player) : TagResolver.empty(),
+                (miniplaceholders) ? MiniPlaceholders.audienceGlobalPlaceholders() : TagResolver.empty()
+            );
         }
 
         return TextUtil.parse(text);

--- a/src/main/java/me/zetastormy/akropolis/util/text/TextUtil.java
+++ b/src/main/java/me/zetastormy/akropolis/util/text/TextUtil.java
@@ -19,6 +19,7 @@
 
 package me.zetastormy.akropolis.util.text;
 
+import net.kyori.adventure.pointer.Pointered;
 import org.bukkit.Color;
 
 import net.kyori.adventure.text.Component;
@@ -39,6 +40,10 @@ public class TextUtil {
 
     public static Component parse(String message, TagResolver resolver) {
         return MINI_MESSAGE.deserialize(message, resolver);
+    }
+
+    public static Component parse(String message, Pointered target, TagResolver... resolver) {
+      return MINI_MESSAGE.deserialize(message, target, resolver);
     }
 
     public static String raw(Component message) {


### PR DESCRIPTION
- Upgrade MiniPlaceholders dependency to v3.1.0
- Fix MiniPlaceholders placeholders not working when PlaceholderAPI is installed